### PR TITLE
ref(systemd): harden unit and move config to env files

### DIFF
--- a/deploy/systemd/webitel-media-exporter.service
+++ b/deploy/systemd/webitel-media-exporter.service
@@ -1,7 +1,6 @@
 [Unit]
-Description=Webitel Media exporter
+Description=Webitel Media Exporter
 After=network.target consul.service rabbitmq-server.service postgresql.service
-
 StartLimitIntervalSec=60
 StartLimitBurst=3
 
@@ -10,25 +9,61 @@ Type=simple
 User=webitel
 Group=webitel
 
-# Restart policy
-Restart=on-failure
-RestartSec=5
-
+EnvironmentFile=/etc/default/webitel-media-exporter
+EnvironmentFile=-/etc/default/webitel-otel
+EnvironmentFile=-/etc/default/webitel
 ExecStart=/usr/local/bin/webitel-media-exporter api
 
+Restart=on-failure
+RestartSec=5
 KillMode=mixed
 KillSignal=SIGTERM
 TimeoutStartSec=0
 TimeoutStopSec=30
-
-# Resource limits
 LimitNOFILE=64000
 LimitNPROC=4096
 
-# Logging
 StandardOutput=journal
 StandardError=journal
 SyslogIdentifier=webitel-media-exporter
+
+# Filesystem isolation
+ProtectSystem=strict
+ProtectHome=yes
+PrivateTmp=yes
+NoExecPaths=/
+ExecPaths=/usr/local/bin/webitel-media-exporter
+ExecPaths=/usr/bin/ffmpeg
+
+# Process isolation
+PrivateDevices=yes
+PrivateUsers=yes
+ProtectKernelTunables=yes
+ProtectKernelModules=yes
+ProtectKernelLogs=yes
+ProtectControlGroups=yes
+ProtectProc=invisible
+ProcSubset=pid
+NoNewPrivileges=yes
+PrivateMounts=yes
+RestrictRealtime=yes
+RestrictSUIDSGID=yes
+RemoveIPC=yes
+RestrictNamespaces=yes
+LockPersonality=yes
+ProtectClock=yes
+ProtectHostname=yes
+SystemCallArchitectures=native
+UMask=0077
+
+# Capabilities & syscalls
+CapabilityBoundingSet=
+RestrictAddressFamilies=AF_INET AF_INET6 AF_UNIX
+SystemCallFilter=@system-service
+SystemCallFilter=~@privileged
+SystemCallFilter=~@resources
+SystemCallFilter=~@obsolete
+SystemCallErrorNumber=EPERM
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Standardize systemd units across services:

- Apply consistent security sandboxing (filesystem/process isolation, syscall filters, capability bounding).
- Drop inline ExecStart flags; configuration now lives in per-unit `/etc/default/<unit>` (EnvironmentFile).
- Fix binary path to `/usr/local/bin/<service>`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)