### PR TITLE
ref(systemd): provide temp dir via CacheDirectory

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,3 +5,5 @@ CONSUL_ID=webitel.media-exporter;
 OTEL_LOG_FORMAT_TIMESTAMP="2006-01-02 15:04:05.000000Z07:00"
 CONSUL=10.10.10.5:8500
 CONSUL_ID=webitel.media-exporter
+
+MEDIA_EXPORTER_TEMP_DIR=/var/cache/webitel-media-exporter

--- a/deploy/systemd/webitel-media-exporter.service
+++ b/deploy/systemd/webitel-media-exporter.service
@@ -8,6 +8,8 @@ StartLimitBurst=3
 Type=simple
 User=webitel
 Group=webitel
+LogsDirectory=webitel
+CacheDirectory=webitel-media-exporter
 
 EnvironmentFile=/etc/default/webitel-media-exporter
 EnvironmentFile=-/etc/default/webitel-otel


### PR DESCRIPTION
Provision the service temp directory via systemd `CacheDirectory` (auto-created under `/var/cache`, owned by webitel, writable under `ProtectSystem=strict`) and set the env default accordingly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)