### PR TITLE
ref(deploy): backport systemd hardening to v26.04

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,3 +5,5 @@ CONSUL_ID=webitel.media-exporter;
 OTEL_LOG_FORMAT_TIMESTAMP="2006-01-02 15:04:05.000000Z07:00"
 CONSUL=10.10.10.5:8500
 CONSUL_ID=webitel.media-exporter
+
+MEDIA_EXPORTER_TEMP_DIR=/var/cache/webitel-media-exporter

--- a/.github/workflows/pull-request-deliver.yml
+++ b/.github/workflows/pull-request-deliver.yml
@@ -16,6 +16,10 @@ jobs:
   version:
     name: Version
     uses: webitel/reusable-workflows/.github/workflows/_version.yml@v2
+    permissions:
+      contents: read
+      id-token: write
+
     if: |
       github.event.workflow_run.head_repository.fork == false &&
       github.event.workflow_run.conclusion == 'success'

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -51,7 +51,7 @@ jobs:
       package-description: ${{ github.event.repository.description }}
       package-contents: |
         src=deploy/systemd/webitel-media-exporter.service dst=/etc/systemd/system/webitel-media-exporter.service type=config
-        src=.env.example dst=/etc/default/webitel-media-exporter type=config
+        src=.env.example dst=/etc/default/webitel-media-exporter type=config mode=0640
         
 
       scripts: |

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -59,7 +59,7 @@ jobs:
       package-description: ${{ github.event.repository.description }}
       package-contents: |
         src=deploy/systemd/webitel-media-exporter.service dst=/etc/systemd/system/webitel-media-exporter.service type=config
-        src=.env.example dst=/etc/default/webitel-media-exporter type=config
+        src=.env.example dst=/etc/default/webitel-media-exporter type=config mode=0640
         
 
       package-depends: 

--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,7 @@ Thumbs.db
 .env.*
 *.env
 !.env.example
-!.env.otel.example
+!.env.*.example
 !.env.sample
 !example.env
 env

--- a/deploy/debian/postinst.sh
+++ b/deploy/debian/postinst.sh
@@ -49,7 +49,7 @@ create_user() {
 # and run under `set -e`: a failing hook aborts the install, which is the
 # correct behaviour when e.g. a required certificate cannot be generated.
 run_postinst_hooks() {
-    local hook_dir="/usr/lib/$DPKG_MAINTSCRIPT_PACKAGE/deb/postinst.d"
+    local hook_dir="/usr/lib/webitel/$DPKG_MAINTSCRIPT_PACKAGE/deb/postinst.d"
     [ -d "$hook_dir" ] || return 0
 
     local hook

--- a/deploy/systemd/webitel-media-exporter.service
+++ b/deploy/systemd/webitel-media-exporter.service
@@ -1,7 +1,6 @@
 [Unit]
-Description=Webitel Media exporter
+Description=Webitel Media Exporter
 After=network.target consul.service rabbitmq-server.service postgresql.service
-
 StartLimitIntervalSec=60
 StartLimitBurst=3
 
@@ -10,25 +9,61 @@ Type=simple
 User=webitel
 Group=webitel
 
-# Restart policy
-Restart=on-failure
-RestartSec=5
-
+EnvironmentFile=/etc/default/webitel-media-exporter
+EnvironmentFile=-/etc/default/webitel-otel
+EnvironmentFile=-/etc/default/webitel
 ExecStart=/usr/local/bin/webitel-media-exporter api
 
+Restart=on-failure
+RestartSec=5
 KillMode=mixed
 KillSignal=SIGTERM
 TimeoutStartSec=0
 TimeoutStopSec=30
-
-# Resource limits
 LimitNOFILE=64000
 LimitNPROC=4096
 
-# Logging
 StandardOutput=journal
 StandardError=journal
 SyslogIdentifier=webitel-media-exporter
+
+# Filesystem isolation
+ProtectSystem=strict
+ProtectHome=yes
+PrivateTmp=yes
+NoExecPaths=/
+ExecPaths=/usr/local/bin/webitel-media-exporter
+ExecPaths=/usr/bin/ffmpeg
+
+# Process isolation
+PrivateDevices=yes
+PrivateUsers=yes
+ProtectKernelTunables=yes
+ProtectKernelModules=yes
+ProtectKernelLogs=yes
+ProtectControlGroups=yes
+ProtectProc=invisible
+ProcSubset=pid
+NoNewPrivileges=yes
+PrivateMounts=yes
+RestrictRealtime=yes
+RestrictSUIDSGID=yes
+RemoveIPC=yes
+RestrictNamespaces=yes
+LockPersonality=yes
+ProtectClock=yes
+ProtectHostname=yes
+SystemCallArchitectures=native
+UMask=0077
+
+# Capabilities & syscalls
+CapabilityBoundingSet=
+RestrictAddressFamilies=AF_INET AF_INET6 AF_UNIX
+SystemCallFilter=@system-service
+SystemCallFilter=~@privileged
+SystemCallFilter=~@resources
+SystemCallFilter=~@obsolete
+SystemCallErrorNumber=EPERM
 
 [Install]
 WantedBy=multi-user.target

--- a/deploy/systemd/webitel-media-exporter.service
+++ b/deploy/systemd/webitel-media-exporter.service
@@ -8,6 +8,8 @@ StartLimitBurst=3
 Type=simple
 User=webitel
 Group=webitel
+LogsDirectory=webitel
+CacheDirectory=webitel-media-exporter
 
 EnvironmentFile=/etc/default/webitel-media-exporter
 EnvironmentFile=-/etc/default/webitel-otel


### PR DESCRIPTION
Backports this cycle's deployment work to the `v26.04` release branch via cherry-pick (deploy/ + env examples + .gitignore + workflow package-contents only).

- standardized & hardened systemd unit(s)
- config moved to `/etc/default/` env-file layering
- `LogsDirectory=webitel`
- directory provisioning via postinst drop-in hooks where needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)