### PR TITLE
fix(buf): track protos main branch on main

### DIFF
--- a/buf.gen.yaml
+++ b/buf.gen.yaml
@@ -24,5 +24,5 @@ plugins:
 inputs:
   # - directory: "../protos/media-exporter"
  - git_repo: "https://github.com/webitel/protos"
-   branch: "v25.12"
+   branch: "main"
    subdir: media-exporter


### PR DESCRIPTION
## What
Point the drifted `buf` proto inputs back at `github.com/webitel/protos` **main** on the `main` branch (they were pinned to a release branch).

## Why
On `main`, buf must track protos `main`; pinning to a release branch belongs only on release branches.

## Note
Config-only change; no generated code is regenerated here.