### PR TITLE
WTEL-8912: Preserve registry sort order in screenshots PDF export

### DIFF
--- a/api/pdf/pdf.pb.go
+++ b/api/pdf/pdf.pb.go
@@ -80,11 +80,13 @@ func (ExportStatus) EnumDescriptor() ([]byte, []int) {
 
 // Request for generating a screen recording PDF.
 type CreateScreenrecordingRequest struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	AgentId       int64                  `protobuf:"varint,1,opt,name=agent_id,json=agentId,proto3" json:"agent_id,omitempty"`        // Unique identifier of the agent.
-	From          int64                  `protobuf:"varint,2,opt,name=from,proto3" json:"from,omitempty"`                             // Start timestamp of the range (Unix millis).
-	To            int64                  `protobuf:"varint,3,opt,name=to,proto3" json:"to,omitempty"`                                 // End timestamp of the range (Unix millis).
-	FileIds       []int64                `protobuf:"varint,4,rep,packed,name=file_ids,json=fileIds,proto3" json:"file_ids,omitempty"` // Optional: specific file IDs to include in the PDF.
+	state   protoimpl.MessageState `protogen:"open.v1"`
+	AgentId int64                  `protobuf:"varint,1,opt,name=agent_id,json=agentId,proto3" json:"agent_id,omitempty"`        // Unique identifier of the agent.
+	From    int64                  `protobuf:"varint,2,opt,name=from,proto3" json:"from,omitempty"`                             // Start timestamp of the range (Unix millis).
+	To      int64                  `protobuf:"varint,3,opt,name=to,proto3" json:"to,omitempty"`                                 // End timestamp of the range (Unix millis).
+	FileIds []int64                `protobuf:"varint,4,rep,packed,name=file_ids,json=fileIds,proto3" json:"file_ids,omitempty"` // Optional: specific file IDs to include in the PDF.
+	// sorting criteria, e.g. "+view_name" or "-uploaded_at"
+	Sort          string `protobuf:"bytes,5,opt,name=sort,proto3" json:"sort,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -145,6 +147,13 @@ func (x *CreateScreenrecordingRequest) GetFileIds() []int64 {
 		return x.FileIds
 	}
 	return nil
+}
+
+func (x *CreateScreenrecordingRequest) GetSort() string {
+	if x != nil {
+		return x.Sort
+	}
+	return ""
 }
 
 // Request for generating a call media PDF.
@@ -270,8 +279,7 @@ func (x *DownloadCallArchiveRequest) GetFileIds() []int64 {
 }
 
 // One frame of a streamed ZIP archive download. The file name is carried via the "filename"
-// gRPC response header (set before the first frame), mirroring how CasesService.ExportCases
-// streams its output — not a field on this message.
+// gRPC response header (set before the first frame)
 type DownloadCallArchiveResponse struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Data          []byte                 `protobuf:"bytes,1,opt,name=data,proto3" json:"data,omitempty"`
@@ -797,12 +805,13 @@ var File_pdf_proto protoreflect.FileDescriptor
 
 const file_pdf_proto_rawDesc = "" +
 	"\n" +
-	"\tpdf.proto\x12\x16webitel_media_exporter\x1a\x1cgoogle/api/annotations.proto\"x\n" +
+	"\tpdf.proto\x12\x16webitel_media_exporter\x1a\x1cgoogle/api/annotations.proto\"\x8c\x01\n" +
 	"\x1cCreateScreenrecordingRequest\x12\x19\n" +
 	"\bagent_id\x18\x01 \x01(\x03R\aagentId\x12\x12\n" +
 	"\x04from\x18\x02 \x01(\x03R\x04from\x12\x0e\n" +
 	"\x02to\x18\x03 \x01(\x03R\x02to\x12\x19\n" +
-	"\bfile_ids\x18\x04 \x03(\x03R\afileIds\"q\n" +
+	"\bfile_ids\x18\x04 \x03(\x03R\afileIds\x12\x12\n" +
+	"\x04sort\x18\x05 \x01(\tR\x04sort\"q\n" +
 	"\x17CreateCallExportRequest\x12\x17\n" +
 	"\acall_id\x18\x01 \x01(\tR\x06callId\x12\x12\n" +
 	"\x04from\x18\x03 \x01(\x03R\x04from\x12\x0e\n" +

--- a/api/pdf/pdf_grpc.pb.go
+++ b/api/pdf/pdf_grpc.pb.go
@@ -46,7 +46,7 @@ type PdfServiceClient interface {
 	ListCallExports(ctx context.Context, in *ListCallHistoryRequest, opts ...grpc.CallOption) (*ListExportsResponse, error)
 	// Streams a ZIP archive bundling the given, already-uploaded call files (e.g. PDFs).
 	// Synchronous: the archive is assembled on the fly and streamed back chunk by chunk,
-	// so the caller does not need to poll for completion or a separate download step.
+	// so the caller does not need to poll for completion.
 	DownloadCallArchive(ctx context.Context, in *DownloadCallArchiveRequest, opts ...grpc.CallOption) (grpc.ServerStreamingClient[DownloadCallArchiveResponse], error)
 	// Deletes a specific export record from the history.
 	DeleteExport(ctx context.Context, in *DeleteExportRequest, opts ...grpc.CallOption) (*DeleteExportResponse, error)
@@ -148,7 +148,7 @@ type PdfServiceServer interface {
 	ListCallExports(context.Context, *ListCallHistoryRequest) (*ListExportsResponse, error)
 	// Streams a ZIP archive bundling the given, already-uploaded call files (e.g. PDFs).
 	// Synchronous: the archive is assembled on the fly and streamed back chunk by chunk,
-	// so the caller does not need to poll for completion or a separate download step.
+	// so the caller does not need to poll for completion.
 	DownloadCallArchive(*DownloadCallArchiveRequest, grpc.ServerStreamingServer[DownloadCallArchiveResponse]) error
 	// Deletes a specific export record from the history.
 	DeleteExport(context.Context, *DeleteExportRequest) (*DeleteExportResponse, error)

--- a/internal/app/pdf_files.go
+++ b/internal/app/pdf_files.go
@@ -14,9 +14,8 @@ import (
 	"github.com/webitel/media-exporter/internal/util"
 )
 
-func downloadScreenshotsForPDF(ctx context.Context, session *model.Session, app *App, files []*storage.File) (map[string]string, map[string]*storage.File, error) {
+func downloadScreenshotsForPDF(ctx context.Context, session *model.Session, app *App, files []*storage.File) (map[string]string, error) {
 	tmpFiles := make(map[string]string)
-	fileInfos := make(map[string]*storage.File)
 	var mu sync.Mutex
 	var wg sync.WaitGroup
 
@@ -34,7 +33,6 @@ func downloadScreenshotsForPDF(ctx context.Context, session *model.Session, app 
 			}
 			mu.Lock()
 			tmpFiles[fmt.Sprint(f.Id)] = tmpPath
-			fileInfos[fmt.Sprint(f.Id)] = f
 			mu.Unlock()
 		}(f)
 	}
@@ -44,11 +42,11 @@ func downloadScreenshotsForPDF(ctx context.Context, session *model.Session, app 
 
 	for err := range errCh {
 		if err != nil {
-			return nil, nil, err
+			return nil, err
 		}
 	}
 
-	return tmpFiles, fileInfos, nil
+	return tmpFiles, nil
 }
 
 func downloadAndResize(ctx context.Context, client storage.FileServiceClient, domainID int64, f *storage.File) (string, error) {

--- a/internal/app/pdf_task.go
+++ b/internal/app/pdf_task.go
@@ -35,6 +35,11 @@ func (app *App) HandlePdfTask(ctx context.Context, session *model.Session, task 
 		return fmt.Errorf("channel missing for task %s: %w", task.TaskID, err)
 	}
 
+	sort := task.Sort
+	if sort == "" {
+		sort = domain.DefaultScreenshotSort
+	}
+
 	var filesResp *storage.ListFile
 
 	if task.AgentID != 0 {
@@ -44,6 +49,7 @@ func (app *App) HandlePdfTask(ctx context.Context, session *model.Session, task 
 			Channel: channel,
 			AgentId: task.AgentID,
 			Size:    1000,
+			Sort:    sort,
 			UploadedAt: &engine.FilterBetween{
 				From: task.From,
 				To:   task.To,
@@ -55,6 +61,7 @@ func (app *App) HandlePdfTask(ctx context.Context, session *model.Session, task 
 			Type:    storage.ScreenrecordingType_SCREENSHOT,
 			Channel: channel,
 			Size:    1000,
+			Sort:    sort,
 			UploadedAt: &engine.FilterBetween{
 				From: task.From,
 				To:   task.To,
@@ -71,7 +78,7 @@ func (app *App) HandlePdfTask(ctx context.Context, session *model.Session, task 
 		return fmt.Errorf("failed to find files: %w", err)
 	}
 
-	tmpFiles, fileInfos, err := downloadScreenshotsForPDF(ctx, session, app, filesResp.Items)
+	tmpFiles, err := downloadScreenshotsForPDF(ctx, session, app, filesResp.Items)
 	if err != nil {
 		slog.ErrorContext(ctx, "downloadScreenshotsForPDF failed", "taskID", task.TaskID, "error", err)
 		_ = SetTaskStatus(app, historyID, task.TaskID, "failed", session.UserID(), nil)
@@ -79,7 +86,7 @@ func (app *App) HandlePdfTask(ctx context.Context, session *model.Session, task 
 	}
 	defer util.CleanupFiles(tmpFiles)
 
-	pdfBytes, err := maroto.GeneratePDF(tmpFiles, fileInfos)
+	pdfBytes, err := maroto.GeneratePDF(filesResp.Items, tmpFiles)
 	if err != nil {
 		slog.ErrorContext(ctx, "GeneratePDF failed", "taskID", task.TaskID, "error", err)
 		_ = SetTaskStatus(app, historyID, task.TaskID, "failed", session.UserID(), nil)

--- a/internal/domain/model/pdf/model.go
+++ b/internal/domain/model/pdf/model.go
@@ -37,6 +37,7 @@ type GenerateExportRequest struct {
 	FileIDs []int64
 	From    int64
 	To      int64
+	Sort    string
 }
 
 // GenerateCallExportRequest used for Calls
@@ -88,6 +89,7 @@ type ExportTask struct {
 	Headers  map[string]string `json:"headers"`
 	IDs      []int64           `json:"ids"`
 	Type     string            `json:"type"`
+	Sort     string            `json:"sort,omitempty"`
 }
 
 type PdfExportMetadata struct {

--- a/internal/domain/model/pdf/sort.go
+++ b/internal/domain/model/pdf/sort.go
@@ -1,0 +1,38 @@
+package domain
+
+import (
+	"fmt"
+	"strings"
+)
+
+const DefaultScreenshotSort = "-uploaded_at"
+
+var allowedScreenshotSortFields = map[string]struct{}{
+	"view_name":   {},
+	"uploaded_at": {},
+}
+
+// NormalizeScreenshotSort validates a sort expression and returns it
+// in the canonical "+field"/"-field" form.
+func NormalizeScreenshotSort(sort string) (string, error) {
+	if sort == "" {
+		return DefaultScreenshotSort, nil
+	}
+
+	direction := "+"
+	field := sort
+	switch sort[0] {
+	case '+', ' ':
+		field = sort[1:]
+	case '-':
+		direction = "-"
+		field = sort[1:]
+	}
+
+	field = strings.ToLower(strings.TrimSpace(field))
+	if _, ok := allowedScreenshotSortFields[field]; !ok {
+		return "", fmt.Errorf("invalid sort field: %q", field)
+	}
+
+	return direction + field, nil
+}

--- a/internal/handler/grpc/pdf.go
+++ b/internal/handler/grpc/pdf.go
@@ -46,6 +46,7 @@ func (h *PdfHandler) CreateScreenrecordingExport(ctx context.Context, req *pdfap
 		FileIDs: req.FileIds,
 		From:    req.From,
 		To:      req.To,
+		Sort:    req.Sort,
 	})
 	if err != nil {
 		return nil, err

--- a/internal/service/pdf.go
+++ b/internal/service/pdf.go
@@ -56,8 +56,14 @@ func (s *PdfServiceImpl) GenerateExport(ctx context.Context, opts *options.Creat
 	if req.AgentID == 0 {
 		return nil, errors.BadRequest("agent_id is required")
 	}
+
+	sort, err := domain.NormalizeScreenshotSort(req.Sort)
+	if err != nil {
+		return nil, errors.BadRequest(err.Error())
+	}
+
 	// Logic moved to a helper to reuse code between Call and Screenrecording
-	return s.createExportTask(ctx, opts, domain.ChannelScreenRecording, req.AgentID, "", req.FileIDs, req.From, req.To)
+	return s.createExportTask(ctx, opts, domain.ChannelScreenRecording, req.AgentID, "", req.FileIDs, req.From, req.To, sort)
 }
 
 func (s *PdfServiceImpl) GetHistory(ctx context.Context, req *domain.PdfHistoryRequestOptions) (*domain.HistoryResponse, error) {
@@ -75,7 +81,7 @@ func (s *PdfServiceImpl) GenerateCallExport(ctx context.Context, opts *options.C
 		return nil, errors.BadRequest("call_id is required")
 	}
 
-	return s.createExportTask(ctx, opts, domain.ChannelCall, 0, req.CallID, req.FileIDs, req.From, req.To)
+	return s.createExportTask(ctx, opts, domain.ChannelCall, 0, req.CallID, req.FileIDs, req.From, req.To, "")
 }
 
 func (s *PdfServiceImpl) GetCallHistory(ctx context.Context, req *domain.CallHistoryRequestOptions) (*domain.HistoryResponse, error) {
@@ -192,6 +198,7 @@ func (s *PdfServiceImpl) createExportTask(
 	callID string,
 	fileIDs []int64,
 	from, to int64,
+	sort string,
 ) (*domain.PdfExportMetadata, error) {
 	now := time.Now()
 
@@ -253,6 +260,7 @@ func (s *PdfServiceImpl) createExportTask(
 		Headers:  domain.ExtractHeadersFromContext(ctx, []string{"authorization", "x-req-id", "x-webitel-access"}),
 		IDs:      fileIDs,
 		Type:     domain.PdfExportType,
+		Sort:     sort,
 	}
 
 	if err := s.cache.PushExportTask(task); err != nil {

--- a/internal/util/pdf/maroto/generator.go
+++ b/internal/util/pdf/maroto/generator.go
@@ -2,25 +2,16 @@ package maroto
 
 import (
 	"fmt"
-	"sort"
-	"time"
 
 	"github.com/johnfercher/maroto/pkg/consts"
 	"github.com/johnfercher/maroto/pkg/pdf"
 	"github.com/webitel/media-exporter/api/storage"
 )
 
-// pdfItem represents a single PDF page item
-type pdfItem struct {
-	Path string
-	Time time.Time
-}
-
 // GeneratePDF creates a PDF document containing only images from the provided file paths.
-// Screenshots are sorted by UploadedAt (int64 Unix timestamp).
 func GeneratePDF(
-	files map[string]string,
-	fileInfos map[string]*storage.File,
+	files []*storage.File,
+	paths map[string]string,
 ) ([]byte, error) {
 
 	m := pdf.NewMaroto(consts.Portrait, consts.A4)
@@ -29,54 +20,17 @@ func GeneratePDF(
 	// A4 portrait height ~297mm, leave margins
 	imageHeight := 250.0
 
-	// --- Collect & normalize data ---
-	items := make([]pdfItem, 0, len(files))
-
-	for id, path := range files {
-		if path == "" {
-			continue
-		}
-
-		info, ok := fileInfos[id]
-		if !ok || info == nil || info.UploadedAt == 0 {
-			// Fallback: include but push to the end
-			items = append(items, pdfItem{
-				Path: path,
-				Time: time.Time{},
-			})
-			continue
-		}
-
-		// Detect seconds vs milliseconds
-		var t time.Time
-		if info.UploadedAt > 1e12 {
-			// milliseconds
-			t = time.UnixMilli(info.UploadedAt)
-		} else {
-			// seconds
-			t = time.Unix(info.UploadedAt, 0)
-		}
-
-		items = append(items, pdfItem{
-			Path: path,
-			Time: t,
-		})
-	}
-
+	items := orderedPaths(files, paths)
 	if len(items) == 0 {
 		return nil, fmt.Errorf("no valid images found for PDF")
 	}
 
-	// --- Sort by time (newest → oldest) ---
-	sort.Slice(items, func(i, j int) bool {
-		return items[i].Time.After(items[j].Time)
-	})
-
 	// --- Build PDF ---
-	for i, item := range items {
+	for i, path := range items {
+		p := path
 		m.Row(imageHeight, func() {
 			m.Col(12, func() {
-				tryAddImage(m, item.Path)
+				tryAddImage(m, p)
 			})
 		})
 
@@ -92,6 +46,20 @@ func GeneratePDF(
 	}
 
 	return buf.Bytes(), nil
+}
+
+// orderedPaths returns downloaded paths in the files order.
+func orderedPaths(files []*storage.File, paths map[string]string) []string {
+	res := make([]string, 0, len(files))
+	for _, f := range files {
+		if f == nil {
+			continue
+		}
+		if p := paths[fmt.Sprint(f.Id)]; p != "" {
+			res = append(res, p)
+		}
+	}
+	return res
 }
 
 // tryAddImage attempts to load and place an image into the PDF.


### PR DESCRIPTION
## Проблема
Supervisor -> Agents -> сторінка оператора -> вкладка Screenshots: при генерації PDF
скриншоти у файлі завжди йшли від найновішого до найстарішого, незалежно від того,
як користувач посортував реєстр (Name або Date&Time). Сортування ніде не передавалось,
а генератор жорстко пересортовував сторінки за часом.

## Вирішення
Сортування протягнуто наскрізь: create-запит -> Redis-задача -> запит у storage.
Сортує SQL storage, генератор більше не пересортовує і зберігає порядок відповіді storage.

## Зміни
- `api/pdf` - регенерація з protos main (нове поле `sort`)
- `sort.go` (новий) - `NormalizeScreenshotSort`: whitelist полів `view_name`/`uploaded_at`,
  канонізація `+field`/`-field`, невалідне поле -> BadRequest на create; дефолт `-uploaded_at`
- `ExportTask` - нове поле `Sort`, їде через Redis до воркера
- `pdf_task.go` - воркер передає `Sort` у `SearchScreenRecordingsByAgent` / `SearchScreenRecordings`
- `generator.go` - `GeneratePDF(files, paths)` будує сторінки в порядку слайса від storage,
  видалено хардкодний пересорт за часом;
  
### Залежність:
https://github.com/webitel/protos/pull/377
https://github.com/webitel/webitel.go/pull/329