### PR TITLE
WTEL-8670 [screenshot size]

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
+
 	"github.com/webitel/media-exporter/internal/errors"
 )
 
@@ -36,7 +37,8 @@ type DatabaseConfig struct {
 }
 
 type ExportConfig struct {
-	Workers int `json:"workers"`
+	Workers            int `json:"workers"`
+	ScreenshotMaxWidth int `json:"screenshotMaxWidth,omitempty"`
 }
 
 func LoadConfig() (*AppConfig, error) {
@@ -76,6 +78,7 @@ func bindFlagsAndEnv() {
 	pflag.Int("redis_db", 0, "Redis DB number")
 	// export
 	pflag.Int("workers", 5, "Number of concurrent export workers")
+	pflag.Int("screenshot_max_width", 400, "Maximum width (px) to which screenshots are downscaled before being placed in the PDF")
 
 	pflag.Parse()
 
@@ -90,6 +93,7 @@ func bindFlagsAndEnv() {
 	_ = viper.BindEnv("redis_addr", "REDIS_ADDR")
 	_ = viper.BindEnv("redis_password", "REDIS_PASSWORD")
 	_ = viper.BindEnv("redis_db", "REDIS_DB")
+	_ = viper.BindEnv("screenshot_max_width", "SCREENSHOT_MAX_WIDTH")
 }
 
 func getConfigFilePath() string {
@@ -119,7 +123,10 @@ func buildAppConfig(file string) *AppConfig {
 		File:     file,
 		TempDir:  tempDir,
 		Database: &DatabaseConfig{Url: viper.GetString("data_source")},
-		Export:   &ExportConfig{Workers: viper.GetInt("workers")},
+		Export: &ExportConfig{
+			Workers:            viper.GetInt("workers"),
+			ScreenshotMaxWidth: viper.GetInt("screenshot_max_width"),
+		},
 		Consul: &ConsulConfig{
 			Id:            viper.GetString("id"),
 			Address:       viper.GetString("consul"),

--- a/internal/app/pdf_files.go
+++ b/internal/app/pdf_files.go
@@ -24,7 +24,7 @@ func downloadScreenshotsForPDF(ctx context.Context, session *model.Session, app 
 		wg.Add(1)
 		go func(f *storage.File) {
 			defer wg.Done()
-			tmpPath, err := downloadAndResize(ctx, app.StorageClient, session.DomainID(), f)
+			tmpPath, err := downloadAndResize(ctx, app.StorageClient, session.DomainID(), f, app.Config.Export.ScreenshotMaxWidth)
 			if err != nil {
 				// FIXME commented as we receive IDs from SearchScreenRecordings which do not exist / or have been deleted
 				//errCh <- err
@@ -49,7 +49,7 @@ func downloadScreenshotsForPDF(ctx context.Context, session *model.Session, app 
 	return tmpFiles, nil
 }
 
-func downloadAndResize(ctx context.Context, client storage.FileServiceClient, domainID int64, f *storage.File) (string, error) {
+func downloadAndResize(ctx context.Context, client storage.FileServiceClient, domainID int64, f *storage.File, maxWidth int) (string, error) {
 	if f.Id == 0 || f.Name == "" {
 		return "", fmt.Errorf("invalid file: id=%d, name=%q", f.Id, f.Name)
 	}
@@ -61,7 +61,7 @@ func downloadAndResize(ctx context.Context, client storage.FileServiceClient, do
 	if err := downloadToFile(ctx, client, domainID, f.Id, tmpPath); err != nil {
 		return "", err
 	}
-	_ = util.ResizeImage(tmpPath, 400)
+	_ = util.ResizeImage(tmpPath, maxWidth)
 	return tmpPath, nil
 }
 

--- a/internal/util/utils.go
+++ b/internal/util/utils.go
@@ -24,12 +24,15 @@ func CleanupFiles(files map[string]string) {
 	}
 }
 
-func ResizeImage(path string, width int) error {
+func ResizeImage(path string, maxWidth int) error {
 	img, err := imaging.Open(path)
 	if err != nil {
 		return err
 	}
-	resized := imaging.Resize(img, width, 0, imaging.Lanczos)
+	if img.Bounds().Dx() <= maxWidth {
+		return nil
+	}
+	resized := imaging.Resize(img, maxWidth, 0, imaging.Lanczos)
 	return imaging.Save(resized, path)
 }
 


### PR DESCRIPTION
fix: add env setting for screenshot size

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable maximum screenshot width for exports through settings, command-line options, and environment variables.
  * PDF exports now use the configured screenshot width.

* **Bug Fixes**
  * Images that already fit within the configured width are no longer unnecessarily resized or saved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->